### PR TITLE
Circleci project setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.3-stretch-node
+      - image: circleci/ruby:3.0.1-stretch-node
     executor: ruby/default
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  ruby: circleci/ruby@0.1.2
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.6.3-stretch-node
+    executor: ruby/default
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/bundle-install
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/ruby:3.0.1-stretch-node
+      - image: circleci/ruby:3.0.1
     executor: ruby/default
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Which bundler?
-          command: bundle -v
+          name: Install bundler gem
+          command: gem install bundler
       - ruby/bundle-install
 
 # Invoke jobs via workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            bundle exec rake db:migrate
             bundle exec rspec spec
 
 # Invoke jobs via workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ jobs:
           name: Install bundler gem
           command: gem install bundler
       - ruby/bundle-install
+      - run:
+          name: Run Tests
+          command: |
+            bundle exec rake db:migrate
+            bundle exec rspec spec
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows


### PR DESCRIPTION
Previous builds failed because of this line:

```
jobs:
  build:
    docker:
      - image: circleci/ruby:2.6.3-stretch-node
```

We wanted to install Ruby 3.0.1 so we changed the image from 2.6.3 to 3.0.1 with the additional deletion of stretch-node. Unknown implications of eliminating stretch-node. Please let me know if this is unacceptable for our needs.

Thank you