### PR TITLE
Create migration to add name column to user table

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/db/migrate/20211217154112_add_name_to_user.rb
+++ b/db/migrate/20211217154112_add_name_to_user.rb
@@ -1,0 +1,5 @@
+class AddNameToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_02_210959) do
+ActiveRecord::Schema.define(version: 2021_12_17_154112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2021_12_02_210959) do
     t.string "address"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name"
   end
 
   add_foreign_key "sub_locations", "users"


### PR DESCRIPTION
I ran `rails g migration` to add a `name` to the User table - this action was based off of the conversation between Gaelyn and I. 

Please let me know if this is inadequate or needs revision.